### PR TITLE
chore: simplify examples by removing advanced syntax

### DIFF
--- a/exemples/SAAS-CRM.tilt
+++ b/exemples/SAAS-CRM.tilt
@@ -15,7 +15,7 @@ use policy     // Guards & rôles (RBAC léger)
 // 1) Schémas de données
 // ---------------------------------------------
 
-db.table("users", schema:{
+db.table("users", {
   id: id,
   email: text,
   password_hash: text,
@@ -24,7 +24,7 @@ db.table("users", schema:{
   created_at: time
 })
 
-db.table("contacts", schema:{
+db.table("contacts", {
   id: id,
   owner_id: id,               // user.id (propriétaire)
   name: text,
@@ -35,7 +35,7 @@ db.table("contacts", schema:{
   created_at: time
 })
 
-db.table("deals", schema:{
+db.table("deals", {
   id: id,
   contact_id: id,
   owner_id: id,               // user.id
@@ -48,7 +48,7 @@ db.table("deals", schema:{
   created_at: time
 })
 
-db.table("notes", schema:{
+db.table("notes", {
   id: id,
   contact_id: id,
   author_id: id,
@@ -73,7 +73,7 @@ guard require_auth() {
 
 guard require_perm(perm:text) {
   let me = auth.current()
-  if !policy.allowed(user: me, perm: perm) { http.abort(403) }
+  if !policy.allowed(me, perm) { http.abort(403) }
 }
 
 // ---------------------------------------------
@@ -82,28 +82,28 @@ guard require_perm(perm:text) {
 
 fn api_signup() -> json {
   let b = http.request.body.json
-  validate.object(b, {
+  if !validate.object(b, {
     email: validate.email(),
-    password: validate.text(min:8, max:200),
-    full_name: validate.text(min:2, max:120)
-  }) or return { ok:false, error:"invalid_input" }
+    password: validate.text(8, 200),
+    full_name: validate.text(2, 120)
+  }) { return { ok:false, error:"invalid_input" } }
 
   // hash par runtime (argon2/bcrypt)
   let h = auth.hash_password(b.password)
   let u = db.insert("users", { id:new_id(), email:b.email, password_hash:h, full_name:b.full_name, created_at:now() })
-  let tok = auth.issue(user_id:u.id, claims:{ role:"user" })
-  auth.set_session(token: tok) // Set-Cookie HttpOnly
+  let tok = auth.issue(u.id, { role:"user" })
+  auth.set_session(tok) // Set-Cookie HttpOnly
   return { ok:true, user:{ id:u.id, email:u.email, full_name:u.full_name } }
 }
 
 fn api_signin() -> json {
   let b = http.request.body.json
-  validate.object(b, { email: validate.email(), password: validate.text(min:1) }) or return { ok:false, error:"invalid_input" }
-  let rows = db.select("users", { email:b.email }, limit:1)
+  if !validate.object(b, { email: validate.email(), password: validate.text(1) }) { return { ok:false, error:"invalid_input" } }
+  let rows = db.select("users", { email:b.email }, 1)
   if len(rows)==0 { return { ok:false, error:"invalid_creds" } }
   if !auth.verify_password(b.password, rows[0].password_hash) { return { ok:false, error:"invalid_creds" } }
-  let tok = auth.issue(user_id:rows[0].id, claims:{ role:rows[0].role })
-  auth.set_session(token: tok)
+  let tok = auth.issue(rows[0].id, { role:rows[0].role })
+  auth.set_session(tok)
   return { ok:true, user:{ id:rows[0].id, email:rows[0].email, full_name:rows[0].full_name, role:rows[0].role } }
 }
 
@@ -123,9 +123,11 @@ fn contacts_list() -> json {
   let me = auth.current()
   let q = http.request.query
   // Filtre par stage + recherche plein texte simple (name/email/company)
-  let stage = q.stage or ""
-  let search = q.q or ""
-  let rows = db.select("contacts", { owner_id: me.id }, limit:500)
+  let stage = ""
+  if q.stage { stage = q.stage }
+  let search = ""
+  if q.q { search = q.q }
+  let rows = db.select("contacts", { owner_id: me.id }, 500)
   let out = []
   for c in rows {
     if stage!="" && c.stage!=stage { continue }
@@ -138,12 +140,12 @@ fn contacts_list() -> json {
 fn contact_create() -> json {
   let me = auth.current()
   let b = http.request.body.json
-  validate.object(b, {
-    name: validate.text(min:2, max:120),
-    email: validate.email(optional:true),
-    company: validate.text(optional:true, max:120),
-    phone: validate.text(optional:true, max:40)
-  }) or return { ok:false, error:"invalid_input" }
+  if !validate.object(b, {
+    name: validate.text(2, 120),
+    email: validate.email(true),
+    company: validate.text(true, 120),
+    phone: validate.text(true, 40)
+  }) { return { ok:false, error:"invalid_input" } }
 
   let row = db.insert("contacts", { id:new_id(), owner_id:me.id, name:b.name, email:b.email, company:b.company, phone:b.phone, created_at:now() })
   return { ok:true, contact: row }
@@ -151,16 +153,18 @@ fn contact_create() -> json {
 
 fn contact_update() -> json {
   let me = auth.current(); let id = http.params.id
-  let c = db.select("contacts", { id:id }, limit:1)
+  let c = db.select("contacts", { id:id }, 1)
   if len(c)==0 || c[0].owner_id!=me.id { http.abort(404) }
   let b = http.request.body.json
-  db.update("contacts", id, { name:b.name, email:b.email, company:b.company, phone:b.phone, stage:(b.stage or c[0].stage) })
+  let stage_new = c[0].stage
+  if b.stage { stage_new = b.stage }
+  db.update("contacts", id, { name:b.name, email:b.email, company:b.company, phone:b.phone, stage:stage_new })
   return { ok:true }
 }
 
 fn contact_delete() -> json {
   let me = auth.current(); let id = http.params.id
-  let c = db.select("contacts", { id:id }, limit:1)
+  let c = db.select("contacts", { id:id }, 1)
   if len(c)==0 || c[0].owner_id!=me.id { http.abort(404) }
   db.delete("contacts", id); return { ok:true }
 }
@@ -176,37 +180,45 @@ route DELETE "/api/contacts/:id"         use [require_auth, require_perm("contac
 
 fn deals_by_step() -> json {
   let me = auth.current()
-  let deals = db.select("deals", { owner_id: me.id }, limit:1000)
+  let deals = db.select("deals", { owner_id: me.id }, 1000)
   let steps = ["new","discovery","proposal","negotiation","closed"]
   let board = {}
   for s in steps { board[s] = [] }
-  for d in deals { board[d.step] = (board[d.step] or []) + [d] }
+  for d in deals {
+    let prev = []
+    if board[d.step] { prev = board[d.step] }
+    board[d.step] = prev + [d]
+  }
   return board
 }
 
 fn deal_create() -> json {
   let me = auth.current(); let b = http.request.body.json
-  validate.object(b, {
+  if !validate.object(b, {
     contact_id: validate.text(),
-    title: validate.text(min:2, max:200),
-    value_cents: validate.int(min:0)
-  }) or return { ok:false, error:"invalid_input" }
+    title: validate.text(2, 200),
+    value_cents: validate.int(0)
+  }) { return { ok:false, error:"invalid_input" } }
   let row = db.insert("deals", { id:new_id(), contact_id:b.contact_id, owner_id:me.id, title:b.title, value_cents:b.value_cents, created_at:now() })
   return { ok:true, deal: row }
 }
 
 fn deal_update() -> json {
   let me = auth.current(); let id = http.params.id
-  let d = db.select("deals", { id:id }, limit:1)
+  let d = db.select("deals", { id:id }, 1)
   if len(d)==0 || d[0].owner_id!=me.id { http.abort(404) }
   let b = http.request.body.json
-  db.update("deals", id, { title:b.title, value_cents:b.value_cents, step:(b.step or d[0].step), status:(b.status or d[0].status), close_date:b.close_date })
+  let step_new = d[0].step
+  if b.step { step_new = b.step }
+  let status_new = d[0].status
+  if b.status { status_new = b.status }
+  db.update("deals", id, { title:b.title, value_cents:b.value_cents, step:step_new, status:status_new, close_date:b.close_date })
   return { ok:true }
 }
 
 fn deal_delete() -> json {
   let me = auth.current(); let id = http.params.id
-  let d = db.select("deals", { id:id }, limit:1)
+  let d = db.select("deals", { id:id }, 1)
   if len(d)==0 || d[0].owner_id!=me.id { http.abort(404) }
   db.delete("deals", id); return { ok:true }
 }
@@ -219,14 +231,15 @@ route DELETE "/api/deals/:id"            use [require_auth, require_perm("deals:
 // KPIs simples (pipeline value, win rate)
 fn kpis() -> json {
   let me = auth.current()
-  let deals = db.select("deals", { owner_id: me.id }, limit:2000)
+  let deals = db.select("deals", { owner_id: me.id }, 2000)
   let total_open = 0; let total_won = 0; let won = 0; let closed = 0
   for d in deals {
     if d.status=="open" { total_open = total_open + d.value_cents }
     if d.status=="won"  { total_won = total_won + d.value_cents; won = won + 1; closed = closed + 1 }
     if d.status=="lost" { closed = closed + 1 }
   }
-  let win_rate = (closed>0) ? (won*100/closed) : 0
+  let win_rate = 0
+  if closed>0 { win_rate = won*100/closed }
   return { total_open_cents: total_open, total_won_cents: total_won, win_rate: win_rate }
 }
 
@@ -238,14 +251,14 @@ route GET "/api/kpis" use [require_auth] -> kpis()
 
 fn note_add() -> json {
   let me = auth.current(); let b = http.request.body.json
-  validate.object(b, { contact_id: validate.text(), body: validate.text(min:1, max:2000) }) or return { ok:false, error:"invalid_input" }
+  if !validate.object(b, { contact_id: validate.text(), body: validate.text(1, 2000) }) { return { ok:false, error:"invalid_input" } }
   let row = db.insert("notes", { id:new_id(), contact_id:b.contact_id, author_id:me.id, body:b.body, created_at:now() })
   return { ok:true, note: row }
 }
 
 fn notes_list() -> json {
   let cid = http.params.contact_id
-  return db.select("notes", { contact_id: cid }, limit:500)
+  return db.select("notes", { contact_id: cid }, 500)
 }
 
 route POST "/api/notes" use [require_auth] -> note_add()
@@ -262,101 +275,116 @@ ui.navbar {
   link "Dashboard" to "/"
   link "Contacts"  to "/contacts"
   link "Deals"     to "/deals"
-  right {
-    button "Sign in"  link to "/signin" when !auth.is_authenticated()
-    menu label (auth.current().full_name or "") when auth.is_authenticated() {
-      item "Settings" link to "/settings"
-      item "Sign out" on click do_signout()
+    right {
+      if !auth.is_authenticated() {
+        button "Sign in"  link to "/signin"
+      }
+      let full = ""
+      if auth.current().full_name { full = auth.current().full_name }
+      if auth.is_authenticated() {
+        menu label full {
+          item "Settings" link to "/settings"
+          item "Sign out" on click do_signout()
+        }
+      }
     }
-  }
 }
 
-fn do_signout() -> json { let r = http.post(url:"/api/auth/signout"); return { redirect: "/signin" } }
+fn do_signout() -> json { let r = http.post("/api/auth/signout"); return { redirect: "/signin" } }
 
 // ---- Sign in / Sign up ----
-ui.page "Sign in" path "/signin" when !auth.is_authenticated() {
-  section pad=48 align="center" {
-    title "Welcome back"
-    form id "f_signin" on submit signin() width=420 {
-      input email:text label "Email" required
-      input password:text label "Password" type="password" required
-      button "Sign in" variant="primary" width="100%"
-      text "No account?" link "Create one" to "/signup"
+if !auth.is_authenticated() {
+  ui.page "Sign in" path "/signin" {
+    section pad=48 align="center" {
+      title "Welcome back"
+      form id "f_signin" on submit signin() width=420 {
+        input email:text label "Email" required
+        input password:text label "Password" type="password" required
+        button "Sign in" variant="primary" width="100%"
+        text "No account?" link "Create one" to "/signup"
+      }
     }
   }
 }
 
 fn signin() -> json {
   let f = ui.form.values
-  let r = http.post(url:"/api/auth/signin", json:{ email:f.email, password:f.password })
+  let r = http.post("/api/auth/signin", { email:f.email, password:f.password })
   if r.ok && r.value.ok { return { redirect:"/" } } else { return { toast:"Invalid credentials" } }
 }
 
-ui.page "Sign up" path "/signup" when !auth.is_authenticated() {
-  section pad=48 align="center" {
-    title "Create your account"
-    form id "f_signup" on submit signup() width=480 {
-      input full_name:text label "Full name" required
-      input email:text label "Email" required
-      input password:text label "Password" type="password" required
-      button "Create account" variant="primary" width="100%"
+if !auth.is_authenticated() {
+  ui.page "Sign up" path "/signup" {
+    section pad=48 align="center" {
+      title "Create your account"
+      form id "f_signup" on submit signup() width=480 {
+        input full_name:text label "Full name" required
+        input email:text label "Email" required
+        input password:text label "Password" type="password" required
+        button "Create account" variant="primary" width="100%"
+      }
     }
   }
 }
 
 fn signup() -> json {
   let f = ui.form.values
-  let r = http.post(url:"/api/auth/signup", json:{ full_name:f.full_name, email:f.email, password:f.password })
+  let r = http.post("/api/auth/signup", { full_name:f.full_name, email:f.email, password:f.password })
   if r.ok && r.value.ok { return { redirect:"/" } } else { return { toast:"Signup failed" } }
 }
 
 // ---- Dashboard ----
-ui.page "Dashboard" path "/" when auth.is_authenticated() {
-  let k = http.get(url:"/api/kpis")
-  section pad=24 {
-    grid cols=3 cols_md=1 gap=16 {
-      card { title "Pipeline" text ((k.value.json.total_open_cents/100)+" € ouverts") }
-      card { title "Won"      text ((k.value.json.total_won_cents/100)+" € gagnés") }
-      card { title "Win rate" text (k.value.json.win_rate+" %") }
+if auth.is_authenticated() {
+  ui.page "Dashboard" path "/" {
+    let k = http.get("/api/kpis")
+    section pad=24 {
+      grid cols=3 cols_md=1 gap=16 {
+        card { title "Pipeline" text ((k.value.json.total_open_cents/100)+" € ouverts") }
+        card { title "Won"      text ((k.value.json.total_won_cents/100)+" € gagnés") }
+        card { title "Win rate" text (k.value.json.win_rate+" %") }
+      }
     }
   }
 }
 
 // ---- Contacts list + detail ----
-ui.page "Contacts" path "/contacts" when auth.is_authenticated() {
-  section pad=24 {
-    form id "search" on submit search_contacts() inline {
-      input q:text label "Search" placeholder "name, email, company"
-      select stage:text label "Stage" options ["","lead","qualified","customer","churn"]
-      button "Filter"
-      button "New" on click open_new_contact()
-    }
+if auth.is_authenticated() {
+  ui.page "Contacts" path "/contacts" {
+    section pad=24 {
+      form id "search" on submit search_contacts() inline {
+        input q:text label "Search" placeholder "name, email, company"
+        select stage:text label "Stage" options ["","lead","qualified","customer","churn"]
+        button "Filter"
+        button "New" on click open_new_contact()
+      }
 
-    let r = http.get(url:"/api/contacts", query: ui.form.values)
-    if r.ok {
-      table {
-        thead ["Name","Email","Company","Stage","Actions"]
-        tbody for c in r.value.json {
-          tr {
-            td c.name
-            td c.email
-            td c.company
-            td badge c.stage
-            td { button "Open" link to ("/contacts/"+c.id) }
+      let r = http.get("/api/contacts", ui.form.values)
+      if r.ok {
+        table {
+          thead ["Name","Email","Company","Stage","Actions"]
+          tbody for c in r.value.json {
+            tr {
+              td c.name
+              td c.email
+              td c.company
+              td badge c.stage
+              td { button "Open" link to ("/contacts/"+c.id) }
+            }
           }
         }
-      }
-    } else { note "No contacts yet." }
+      } else { note "No contacts yet." }
+    }
   }
 }
 
 fn search_contacts() -> json { return { reload:true } }
 
-ui.page "Contact" path "/contacts/:id" when auth.is_authenticated() {
-  let id = ui.params.id
-  let items = http.get(url:"/api/notes/"+id)
-  section pad=24 {
-    grid cols=3 cols_md=1 gap=24 {
+if auth.is_authenticated() {
+  ui.page "Contact" path "/contacts/:id" {
+    let id = ui.params.id
+    let items = http.get("/api/notes/"+id)
+    section pad=24 {
+      grid cols=3 cols_md=1 gap=24 {
       // Colonne 1–2 : détails
       span col=2 {
         // (MVP) simple formulaire d'édition
@@ -380,34 +408,39 @@ ui.page "Contact" path "/contacts/:id" when auth.is_authenticated() {
           list for n in items.value.json { card { text n.body meta n.created_at } }
         }
       }
+      }
     }
   }
 }
 
 fn save_contact(id:text) -> json {
   let f = ui.form.values
-  let r = http.put(url:("/api/contacts/"+id), json:{ name:f.name, email:f.email, company:f.company, phone:f.phone, stage:f.stage })
+  let r = http.put("/api/contacts/"+id, { name:f.name, email:f.email, company:f.company, phone:f.phone, stage:f.stage })
   if r.ok { return { toast:"Saved" } } else { return { toast:"Save error" } }
 }
 
 fn add_note(cid:text) -> json {
   let f = ui.form.values
-  let r = http.post(url:"/api/notes", json:{ contact_id:cid, body:f.body })
-  return r.ok ? { reload:true } : { toast:"Error" }
+  let r = http.post("/api/notes", { contact_id:cid, body:f.body })
+  if r.ok { return { reload:true } } else { return { toast:"Error" } }
 }
 
 // ---- Deals board (Kanban) ----
-ui.page "Deals" path "/deals" when auth.is_authenticated() {
-  section pad=24 {
-    actions { button "New deal" on click open_new_deal() }
-    let b = http.get(url:"/api/deals/board")
-    if b.ok {
-      grid cols=5 cols_md=1 gap=16 {
-        for step in ["new","discovery","proposal","negotiation","closed"] {
-          card { title step
-            list for d in (b.value.json[step] or []) {
-              card { title d.title text ((d.value_cents/100)+" €")
-                actions { button "Open" on click open_deal(d.id) }
+if auth.is_authenticated() {
+  ui.page "Deals" path "/deals" {
+    section pad=24 {
+      actions { button "New deal" on click open_new_deal() }
+      let b = http.get("/api/deals/board")
+      if b.ok {
+        grid cols=5 cols_md=1 gap=16 {
+          for step in ["new","discovery","proposal","negotiation","closed"] {
+            card { title step
+              let items = b.value.json[step]
+              if !items { items = [] }
+              list for d in items {
+                card { title d.title text ((d.value_cents/100)+" €")
+                  actions { button "Open" on click open_deal(d.id) }
+                }
               }
             }
           }
@@ -420,16 +453,18 @@ ui.page "Deals" path "/deals" when auth.is_authenticated() {
 // Dialogs (MVP simulés via pages modales)
 fn open_new_contact() -> json { return { dialog:"new_contact" } }
 ui.dialog "new_contact" { form id "nc" on submit create_contact() { input name:text label "Name" required input email:text label "Email" input company:text label "Company" input phone:text label "Phone" button "Create" variant:"primary" } }
-fn create_contact() -> json { let f = ui.form.values; let r = http.post(url:"/api/contacts", json:{ name:f.name, email:f.email, company:f.company, phone:f.phone }); return r.ok ? { reload:true } : { toast:"Error" } }
+fn create_contact() -> json { let f = ui.form.values; let r = http.post("/api/contacts", { name:f.name, email:f.email, company:f.company, phone:f.phone }); if r.ok { return { reload:true } } else { return { toast:"Error" } } }
 
 fn open_new_deal() -> json { return { dialog:"new_deal" } }
 ui.dialog "new_deal" { form id "nd" on submit create_deal() { input contact_id:text label "Contact ID" required input title:text label "Title" required input value_cents:int label "Amount (cents)" required button "Create" variant:"primary" } }
-fn create_deal() -> json { let f = ui.form.values; let r = http.post(url:"/api/deals", json:{ contact_id:f.contact_id, title:f.title, value_cents:f.value_cents }); return r.ok ? { reload:true } : { toast:"Error" } }
+fn create_deal() -> json { let f = ui.form.values; let r = http.post("/api/deals", { contact_id:f.contact_id, title:f.title, value_cents:f.value_cents }); if r.ok { return { reload:true } } else { return { toast:"Error" } } }
 
 fn open_deal(id:text) -> json { return { route:("/deals/"+id) } }
 
 // Settings (placeholder)
-ui.page "Settings" path "/settings" when auth.is_authenticated() { section pad=24 { title "Settings" text "Profile & preferences soon." } }
+if auth.is_authenticated() {
+  ui.page "Settings" path "/settings" { section pad=24 { title "Settings" text "Profile & preferences soon." } }
+}
 
 // ---------------------------------------------
 // 8) Utils (helpers de confort)

--- a/exemples/multiple-app.tilt
+++ b/exemples/multiple-app.tilt
@@ -12,10 +12,10 @@ use db
 use ui
 
 // Schéma
-db.table("todos", schema:{ id:id, title:text, done:bool=false, created_at:time })
+db.table("todos", { id:id, title:text, done:bool=false, created_at:time })
 
 // API
-fn list_todos() -> json { return db.select("todos", {}, limit:200) }
+fn list_todos() -> json { return db.select("todos", {}, 200) }
 fn add_todo()  -> json {
   let b = http.request.body.json
   let row = db.insert("todos", { id:new_id(), title:b.title, created_at:now() })
@@ -23,7 +23,7 @@ fn add_todo()  -> json {
 }
 fn toggle_done() -> json {
   let id = http.params.id
-  let t = db.select("todos", { id:id }, limit:1)
+  let t = db.select("todos", { id:id }, 1)
   if len(t)==0 { return { ok:false, error:"not_found" } }
   db.update("todos", id, { done: !t[0].done })
   return { ok:true }
@@ -58,9 +58,9 @@ fn do_toggle(id:id) -> json { let r = http.post("/api/todos/"+id+"/t", {})
 use validate
 
 // Schémas
-db.table("products", schema:{ id:id, name:text, price_cents:int, image_url:text, stock:int=0, created_at:time })
-db.table("carts",    schema:{ id:id, created_at:time })
-db.table("cart_items", schema:{ id:id, cart_id:id, product_id:id, qty:int=1 })
+db.table("products", { id:id, name:text, price_cents:int, image_url:text, stock:int=0, created_at:time })
+db.table("carts",    { id:id, created_at:time })
+db.table("cart_items", { id:id, cart_id:id, product_id:id, qty:int=1 })
 
 fn ensure_cart() -> text {
   let cid = ui.cookie.get("cart_id")
@@ -68,19 +68,19 @@ fn ensure_cart() -> text {
   return cid
 }
 
-fn api_products() -> json { return db.select("products", {}, limit:200) }
+fn api_products() -> json { return db.select("products", {}, 200) }
 fn api_cart() -> json {
   let cid = ensure_cart(); let items = db.select("cart_items", { cart_id:cid })
   let out = []; let total = 0
   for it in items {
-    let p = db.select("products", { id:it.product_id }, limit:1)
+    let p = db.select("products", { id:it.product_id }, 1)
     if len(p)>0 { let line = it.qty * p[0].price_cents; total = total + line; out = out + [{ id:it.id, name:p[0].name, price_cents:p[0].price_cents, image_url:p[0].image_url, qty:it.qty, product_id:it.product_id, line_total:line }] }
   }
   return { cart_id:cid, items:out, total_cents:total }
 }
 fn api_add_to_cart() -> json {
   let b = http.request.body.json
-  let cid = ensure_cart(); let row = db.select("cart_items", { cart_id:cid, product_id:b.product_id }, limit:1)
+  let cid = ensure_cart(); let row = db.select("cart_items", { cart_id:cid, product_id:b.product_id }, 1)
   if len(row)==0 { 
     let qty = 1
     if b.qty { qty = b.qty }
@@ -126,9 +126,9 @@ ui.page "Cart" path "/cart" {
 use auth
 
 // Schémas
-db.table("users", schema:{ id:id, email:text, password_hash:text, full_name:text, role:text="user", created_at:time })
-db.table("contacts", schema:{ id:id, owner_id:id, name:text, email:text, company:text, phone:text, stage:text="lead", created_at:time })
-db.table("deals", schema:{ id:id, contact_id:id, owner_id:id, title:text, value_cents:int, status:text="open", step:text="new", created_at:time })
+db.table("users", { id:id, email:text, password_hash:text, full_name:text, role:text="user", created_at:time })
+db.table("contacts", { id:id, owner_id:id, name:text, email:text, company:text, phone:text, stage:text="lead", created_at:time })
+db.table("deals", { id:id, contact_id:id, owner_id:id, title:text, value_cents:int, status:text="open", step:text="new", created_at:time })
 
 guard require_auth(){ if !auth.is_authenticated(){ http.abort(401) } }
 
@@ -136,21 +136,21 @@ guard require_auth(){ if !auth.is_authenticated(){ http.abort(401) } }
 fn signup() -> json {
   let b = http.request.body.json
   let u = db.insert("users", { id:new_id(), email:b.email, password_hash:auth.hash_password(b.password), full_name:b.full_name, created_at:now() })
-  auth.set_session(token: auth.issue(user_id:u.id, claims:{ role:"user" }))
+  auth.set_session(auth.issue(u.id, { role:"user" }))
   return { ok:true }
 }
 fn signin() -> json {
   let b = http.request.body.json
-  let r = db.select("users", { email:b.email }, limit:1)
+  let r = db.select("users", { email:b.email }, 1)
   if len(r)==0 || !auth.verify_password(b.password, r[0].password_hash) { return { ok:false, error:"invalid_creds" } }
-  auth.set_session(token: auth.issue(user_id:r[0].id, claims:{ role:r[0].role }))
+  auth.set_session(auth.issue(r[0].id, { role:r[0].role }))
   return { ok:true }
 }
 route POST "/api/auth/signup" -> signup()
 route POST "/api/auth/signin" -> signin()
 
 // Contacts API
-fn contacts_list() -> json { let me = auth.current(); return db.select("contacts", { owner_id:me.id }, limit:500) }
+fn contacts_list() -> json { let me = auth.current(); return db.select("contacts", { owner_id:me.id }, 500) }
 fn contact_create() -> json {
   let me = auth.current(); let b = http.request.body.json
   let row = db.insert("contacts", { id:new_id(), owner_id:me.id, name:b.name, email:b.email, company:b.company, phone:b.phone, created_at:now() })
@@ -161,19 +161,23 @@ route POST "/api/contacts" use [require_auth] -> contact_create()
 
 // UI
 ui.navbar { brand "TILT CRM"; link "Dashboard" to "/"; link "Contacts" to "/contacts" }
-ui.page "Sign in" path "/signin" when !auth.is_authenticated() {
-  section pad=48 align:"center" { form id="f" on_submit=do_signin() width=420 { input email:text label "Email" required; input password:text type:"password" label "Password" required; button "Sign in" variant="primary" width:"100%" } }
+if !auth.is_authenticated() {
+  ui.page "Sign in" path "/signin" {
+    section pad=48 align:"center" { form id="f" on_submit=do_signin() width=420 { input email:text label "Email" required; input password:text type:"password" label "Password" required; button "Sign in" variant="primary" width:"100%" } }
+  }
 }
 fn do_signin() -> json { let f = ui.form.values; let r = http.post("/api/auth/signin", { email:f.email, password:f.password })
   if r.ok { return { redirect:"/" } } else { return { toast:"Invalid" } } }
 
-ui.page "Contacts" path "/contacts" when auth.is_authenticated() {
-  section pad=24 {
-    actions { button "New" on_click=open_new() }
-    let r = http.get("/api/contacts")
-    if r.ok {
-      table { thead ["Name","Email","Company","Phone"]; tbody for c in r.value.json { tr { td c.name; td c.email; td c.company; td c.phone } } }
-    } else { note "No contacts" }
+if auth.is_authenticated() {
+  ui.page "Contacts" path "/contacts" {
+    section pad=24 {
+      actions { button "New" on_click=open_new() }
+      let r = http.get("/api/contacts")
+      if r.ok {
+        table { thead ["Name","Email","Company","Phone"]; tbody for c in r.value.json { tr { td c.name; td c.email; td c.company; td c.phone } } }
+      } else { note "No contacts" }
+    }
   }
 }
 ui.dialog "new_contact" { form id="nc" on_submit=create_contact() { input name:text label "Name" required; input email:text label "Email"; input company:text label "Company"; input phone:text label "Phone"; button "Create" variant="primary" } }
@@ -184,11 +188,11 @@ fn create_contact() -> json { let f=ui.form.values
 
 // ============ 4) SITE WEB (landing + blog) ==== 
 // DB
-db.table("posts", schema:{ id:id, title:text, excerpt:text, body:text, published:bool=true, created_at:time })
+db.table("posts", { id:id, title:text, excerpt:text, body:text, published:bool=true, created_at:time })
 
 // API
-fn api_posts() -> json { return db.select("posts", { published:true }, limit:100) }
-fn api_post()  -> json { let id=http.params.id; let r=db.select("posts", { id:id }, limit:1); return len(r)==0 ? { error:"not_found" } : r[0] }
+fn api_posts() -> json { return db.select("posts", { published:true }, 100) }
+fn api_post()  -> json { let id=http.params.id; let r=db.select("posts", { id:id }, 1); if len(r)==0 { return { error:"not_found" } } else { return r[0] } }
 route GET "/api/posts"    -> api_posts()
 route GET "/api/posts/:id" -> api_post()
 

--- a/exemples/todo.tilt
+++ b/exemples/todo.tilt
@@ -3,7 +3,7 @@ use ui
 use http
 
 // --- Data ---
-db.table("todos", schema:{ id:id, title:text, done:bool=false, created:time })
+db.table("todos", { id:id, title:text, done:bool=false, created:time })
 
 // --- Actions ---
 fn add_todo(title:text) -> json {

--- a/exemples/website.tilt
+++ b/exemples/website.tilt
@@ -11,7 +11,7 @@ use ui                        // Importe le module d'interface déclarative (ren
 // 1) Modèle de données (schémas de tables)
 // -------------------------------
 
-db.table("blog_posts", schema:{ // Déclare/assure l'existence de la table 'blog_posts' avec ce schéma
+db.table("blog_posts", { // Déclare/assure l'existence de la table 'blog_posts' avec ce schéma
   id: id,                       // Colonne 'id' (identifiant unique)
   title: text,                  // Titre de l'article (texte)
   excerpt: text,                // Extrait/accroche (texte court)
@@ -20,7 +20,7 @@ db.table("blog_posts", schema:{ // Déclare/assure l'existence de la table 'blog
   created_at: time              // Timestamp de création
 })                              // Fin de la déclaration de la table 'blog_posts'
 
-db.table("contacts", schema:{   // Déclare/assure l'existence de la table 'contacts'
+db.table("contacts", {   // Déclare/assure l'existence de la table 'contacts'
   id: id,                       // Identifiant du message
   email: text,                  // Email de l'expéditeur
   subject: text,                // Sujet du message
@@ -33,7 +33,7 @@ db.table("contacts", schema:{   // Déclare/assure l'existence de la table 'cont
 // -------------------------------
 
 fn seed_posts() -> json {       // Fonction qui insère des posts par défaut, renvoie un JSON
-  let rows = db.select("blog_posts", {}, limit: 1) // Lit 1 ligne pour savoir si la table contient déjà des données
+  let rows = db.select("blog_posts", {}, 1) // Lit 1 ligne pour savoir si la table contient déjà des données
   if len(rows) > 0 {            // Si au moins un post existe
     return { ok: true, seeded: false } // On indique qu'on n'a rien seedé
   }                             // Fin du if
@@ -78,7 +78,7 @@ fn seed_posts() -> json {       // Fonction qui insère des posts par défaut, r
 // -------------------------------
 
 fn api_list_posts() -> json {   // Endpoint pour lister les articles publiés
-  let rows = db.select("blog_posts", { published: true }, limit: 100) // Sélectionne jusqu'à 100 posts publiés
+  let rows = db.select("blog_posts", { published: true }, 100) // Sélectionne jusqu'à 100 posts publiés
   let out = []                  // Initialise la liste de sortie
   for r in rows {               // Pour chaque ligne renvoyée par la DB
     out = out + [{             // Ajoute un objet simplifié à la liste de sortie (concaténation de liste)
@@ -93,7 +93,7 @@ fn api_list_posts() -> json {   // Endpoint pour lister les articles publiés
 
 fn api_get_post() -> json {     // Endpoint pour obtenir le détail d'un article
   let pid = http.params.id      // Récupère l'identifiant depuis l'URL (paramètre de chemin)
-  let rows = db.select("blog_posts", { id: pid }, limit: 1) // Cherche le post correspondant
+  let rows = db.select("blog_posts", { id: pid }, 1) // Cherche le post correspondant
   if len(rows) == 0 {           // Si aucun trouvé
     return { error: "not_found" } // Renvoie une erreur simple
   }                             // Fin du if
@@ -170,7 +170,7 @@ ui.page "Home" {                // Déclare la page d'accueil (chemin par défau
 ui.page "Blog" path "/blog" {  // Déclare la page Blog, accessible via /blog
   section {                     // Section principale
     title "Derniers articles"   // Titre de section
-    let resp = http.get(url: "/api/posts") // Appelle l'API interne pour récupérer les posts
+    let resp = http.get("/api/posts") // Appelle l'API interne pour récupérer les posts
     if resp.ok {                // Si la requête a réussi
       list for p in resp.value.json { // Itère sur le tableau JSON renvoyé
         card link to ("/blog/" + p.id) { // Chaque post est une carte cliquable vers /blog/:id
@@ -187,7 +187,7 @@ ui.page "Blog" path "/blog" {  // Déclare la page Blog, accessible via /blog
 
 ui.page "Post" path "/blog/:id" { // Post detail page, :id path param
   let id = ui.params.id
-  let resp = http.get(url: "/api/posts/" + id)
+  let resp = http.get("/api/posts/" + id)
 
   if resp.ok {
     let post = resp.value.json
@@ -217,7 +217,7 @@ ui.page "Contact" path "/contact" {
 
 fn send_contact() -> json {       // Fonction appelée lors de la soumission du formulaire
   let f = ui.form.values          // Récupère les valeurs du formulaire depuis le runtime UI
-  let r = http.post(url: "/api/contact", json: { // Envoie ces valeurs à l'API de contact
+  let r = http.post("/api/contact", { // Envoie ces valeurs à l'API de contact
     email: f.email,               // Champ email
     subject: f.subject,           // Champ sujet
     message: f.message            // Champ message


### PR DESCRIPTION
## Summary
- drop named arguments, `when` clauses, and coalescing/ternary syntax from examples
- adjust example logic to use basic conditionals

## Testing
- `python - <<'PY'
import sys
files = ['exemples/SAAS-CRM.tilt','exemples/multiple-app.tilt','exemples/todo.tilt','exemples/website.tilt']
try:
    import tilt.parser
except ImportError as e:
    print('IMPORT_ERROR', e)
    sys.exit(1)
for f in files:
    with open(f) as fh:
        src = fh.read()
    tilt.parser.parse_program(src)
    print('PARSED', f)
PY` *(fails: No module named 'tilt')*

------
https://chatgpt.com/codex/tasks/task_e_689a01394bdc8327b215ebc81469ce36